### PR TITLE
Support SSH tunnelling with :jump_authority option

### DIFF
--- a/lib/dicon.ex
+++ b/lib/dicon.ex
@@ -91,13 +91,13 @@ defmodule Dicon do
   end
 
   defp assert_filtered_hosts_exist(hosts, filtered_hosts) do
-    if unknown_host = Enum.find(filtered_hosts, &(not (&1 in hosts))) do
+    if unknown_host = Enum.find(filtered_hosts, &(&1 not in hosts)) do
       Mix.raise("Unknown host: #{inspect(Atom.to_string(unknown_host))}")
     end
   end
 
   defp host_selector([], skip) do
-    &(not (&1 in skip))
+    &(&1 not in skip)
   end
 
   defp host_selector(only, skip) do

--- a/lib/dicon/executor.ex
+++ b/lib/dicon/executor.ex
@@ -14,11 +14,14 @@ defmodule Dicon.Executor do
 
   defstruct [:executor, :conn]
 
+  @type host_config_opt() :: {:authority, binary()} | {:jump_authority, binary()}
+
   @doc """
   Connects to the given authority, returning a term that identifies the
   connection.
   """
-  @callback connect(authority :: binary) :: {:ok, conn} | {:error, binary}
+  @callback connect(authority :: binary, host_config_opts :: [host_config_opt()]) ::
+              {:ok, conn} | {:error, binary}
 
   @doc """
   Executes the given `command` on the given connection, writing the output of
@@ -47,11 +50,11 @@ defmodule Dicon.Executor do
       %Dicon.Executor{} = Dicon.Executor.connect("meg:secret@example.com")
 
   """
-  @spec connect(binary) :: {:ok, t} | {:error, term}
-  def connect(authority) do
+  @spec connect(binary, [host_config_opt()]) :: t()
+  def connect(authority, host_config_opts \\ []) do
     executor = Application.get_env(:dicon, :executor, SecureShell)
 
-    case executor.connect(authority) do
+    case executor.connect(authority, host_config_opts) do
       {:ok, conn} ->
         Mix.shell().info("Connected to #{authority}")
         %__MODULE__{executor: executor, conn: conn}

--- a/lib/dicon/secure_shell.ex
+++ b/lib/dicon/secure_shell.ex
@@ -24,6 +24,21 @@ defmodule Dicon.SecureShell do
     * `:exec_timeout` - an integer that specifies the timeout (in milliseconds)
       when executing commands on the host.
 
+    * `:silently_accept_hosts` - a boolean that specifies how to handle unknown
+      host keys. Defaults to `true`.
+      If `true`, the client accepts any unknown host key without user interaction.
+      If `false`, the client will ask the user via stdio whether to accept or
+      reject the new host key. The decision to save the key if accepted is
+      governed by the `:save_accepted_host` option.
+
+    * `:save_accepted_host` - a boolean that specifies whether to save an
+      accepted host key to the `known_hosts` file (see the `:dir` option for its
+      location). Defaults to `false`.
+      If `true`, an accepted host key is saved if the connection proceeds.
+      If `false`, an accepted host key is not saved. This means the host may
+      still be treated as unknown on subsequent connections, and the behavior
+      defined by `:silently_accept_hosts` would apply again.
+
   The username and password user to connect to the server will be picked up by
   the URL that identifies that server (in `:dicon`'s configuration); read more
   about this in the documentation for the `Dicon` module.
@@ -38,44 +53,111 @@ defmodule Dicon.SecureShell do
     :conn,
     :connect_timeout,
     :write_timeout,
-    :exec_timeout
+    :exec_timeout,
+    :silently_accept_hosts,
+    :save_accepted_host
   ]
 
-  def connect(authority) do
+  @localhost {127, 0, 0, 1}
+
+  @impl Dicon.Executor
+  def connect(authority, host_config) do
     config = Application.get_env(:dicon, __MODULE__, [])
     connect_timeout = Keyword.get(config, :connect_timeout, 5_000)
     write_timeout = Keyword.get(config, :write_timeout, 5_000)
     exec_timeout = Keyword.get(config, :exec_timeout, 5_000)
-    user_dir = Keyword.get(config, :dir, "~/.ssh") |> Path.expand()
-    {user, passwd, host, port} = parse_elements(authority)
+    silently_accept_hosts = Keyword.get(config, :silently_accept_hosts, true)
+    save_accepted_host = Keyword.get(config, :save_accepted_host, false)
 
-    opts =
-      put_option([], :user, user)
-      |> put_option(:password, passwd)
+    user_dir = config |> Keyword.get(:dir, "~/.ssh") |> Path.expand() |> String.to_charlist()
+
+    connect_options =
+      []
       |> put_option(:user_dir, user_dir)
+      |> put_option(:silently_accept_hosts, silently_accept_hosts)
+      |> put_option(:save_accepted_host, save_accepted_host)
 
-    host = String.to_charlist(host)
+    target_authority = parse_authority(authority)
 
-    result =
-      with :ok <- ensure_started(),
-           {:ok, conn} <- :ssh.connect(host, port, opts, connect_timeout) do
-        state = %__MODULE__{
-          conn: conn,
-          connect_timeout: connect_timeout,
-          write_timeout: write_timeout,
-          exec_timeout: exec_timeout
-        }
-
-        {:ok, state}
+    jump_authority =
+      case Keyword.fetch(host_config, :jump_authority) do
+        {:ok, jump_authority} -> parse_authority(jump_authority)
+        :error -> nil
       end
 
-    format_if_error(result)
+    with :ok <- ensure_started(),
+         {:ok, conn} <-
+           connect(target_authority, jump_authority, connect_options, connect_timeout) do
+      state = %__MODULE__{
+        conn: conn,
+        connect_timeout: connect_timeout,
+        write_timeout: write_timeout,
+        exec_timeout: exec_timeout
+      }
+
+      {:ok, state}
+    else
+      error -> format_if_error(error)
+    end
   end
 
-  defp put_option(opts, _key, nil), do: opts
+  defp connect({user, password, host, port}, connect_options, connect_timeout) do
+    connect_options =
+      connect_options
+      |> put_option(:user, user)
+      |> put_option(:password, password)
 
-  defp put_option(opts, key, value) do
-    [{key, String.to_charlist(value)} | opts]
+    :ssh.connect(host, port, connect_options, connect_timeout)
+  end
+
+  defp connect(target_authority, nil, connect_options, connect_timeout) do
+    connect(target_authority, connect_options, connect_timeout)
+  end
+
+  if Code.ensure_loaded?(:ssh) and function_exported?(:ssh, :tcpip_tunnel_to_server, 6) do
+    defp connect(target_authority, jump_authority, connect_options, connect_timeout) do
+      {target_user, target_password, target_host, target_port} = target_authority
+
+      with {:ok, jump_conn} <- connect(jump_authority, connect_options, connect_timeout),
+           {:ok, tunnel_port} <-
+             :ssh.tcpip_tunnel_to_server(
+               jump_conn,
+               @localhost,
+               0,
+               target_host,
+               target_port,
+               connect_timeout
+             ) do
+        # Wait a bit for the tunnel to be available.
+        Process.sleep(1_000)
+        tunnel_authority = {target_user, target_password, @localhost, tunnel_port}
+
+        connect_to_tunnel(tunnel_authority, connect_options, connect_timeout)
+      end
+    end
+
+    defp connect_to_tunnel(authority, connect_options, connect_timeout, retries \\ 2) do
+      with {:error, :timeout} <- connect(authority, connect_options, connect_timeout) do
+        if retries > 0 do
+          Process.sleep(1_000)
+          connect_to_tunnel(authority, connect_options, connect_timeout, retries - 1)
+        else
+          {:error, :timeout}
+        end
+      end
+    end
+  else
+    defp connect(_target_authority, _jump_authority, _connect_options, _connect_timeout) do
+      {:error, ":jump_authority option is only supported in OTP 23+"}
+    end
+  end
+
+  defp put_option(options, key, value) do
+    if value do
+      Keyword.put(options, key, value)
+    else
+      options
+    end
   end
 
   defp ensure_started() do
@@ -91,35 +173,24 @@ defmodule Dicon.SecureShell do
     end
   end
 
-  defp parse_elements(authority) do
-    parts = String.split(authority, "@", parts: 2)
-
-    [user_info, host_info] =
-      case parts do
-        [host_info] ->
-          ["", host_info]
-
-        result ->
-          result
-      end
+  defp parse_authority(authority) do
+    %URI{host: host, port: port, userinfo: user_info} = URI.parse("ssh://" <> authority)
 
     parts = String.split(user_info, ":", parts: 2, trim: true)
-    destructure([user, passwd], parts)
+    destructure([user, password], parts)
 
-    parts = String.split(host_info, ":", parts: 2, trim: true)
-
-    {host, port} =
-      case parts do
-        [host, port] ->
-          {host, String.to_integer(port)}
-
-        [host] ->
-          {host, 22}
-      end
-
-    {user, passwd, host, port}
+    {maybe_to_charlist(user), maybe_to_charlist(password), maybe_to_charlist(host), port || 22}
   end
 
+  defp maybe_to_charlist(value) do
+    if is_binary(value) do
+      String.to_charlist(value)
+    else
+      value
+    end
+  end
+
+  @impl Dicon.Executor
   def exec(%__MODULE__{} = state, command, device) do
     %{conn: conn, connect_timeout: connect_timeout, exec_timeout: exec_timeout} = state
 
@@ -150,6 +221,7 @@ defmodule Dicon.SecureShell do
     end
   end
 
+  @impl Dicon.Executor
   def write_file(%__MODULE__{} = state, target, content, :append) do
     write_file(state, ["cat >> ", target], content)
   end
@@ -172,6 +244,7 @@ defmodule Dicon.SecureShell do
     format_if_error(result)
   end
 
+  @impl Dicon.Executor
   def copy(%__MODULE__{} = state, source, target) do
     %{conn: conn, connect_timeout: connect_timeout, exec_timeout: exec_timeout} = state
 

--- a/lib/dicon/secure_shell.ex
+++ b/lib/dicon/secure_shell.ex
@@ -289,7 +289,7 @@ defmodule Dicon.SecureShell do
 
   defp format_if_error({:error, reason}) do
     case :inet.format_error(reason) do
-      'unknown POSIX error' ->
+      ~c"unknown POSIX error" ->
         {:error, inspect(reason)}
 
       message ->

--- a/lib/mix/tasks/dicon.control.ex
+++ b/lib/mix/tasks/dicon.control.ex
@@ -29,8 +29,8 @@ defmodule Mix.Tasks.Dicon.Control do
       {opts, [command], []} ->
         for host <- config(:hosts, opts) do
           host_config = host_config(host)
-          authority = Keyword.fetch!(host_config, :authority)
-          conn = Executor.connect(authority)
+          {authority, host_config} = Keyword.pop!(host_config, :authority)
+          conn = Executor.connect(authority, host_config)
           exec(conn, host_config, config(:target_dir), command)
         end
 

--- a/lib/mix/tasks/dicon.deploy.ex
+++ b/lib/mix/tasks/dicon.deploy.ex
@@ -34,8 +34,8 @@ defmodule Mix.Tasks.Dicon.Deploy do
 
         for host <- config(:hosts, opts) do
           host_config = host_config(host)
-          authority = Keyword.fetch!(host_config, :authority)
-          conn = Executor.connect(authority)
+          {authority, host_config} = Keyword.pop(host_config, :authority)
+          conn = Executor.connect(authority, host_config)
           release_file = upload(conn, [source], target_dir)
           target_dir = [target_dir, ?/, version]
           unpack(conn, release_file, target_dir)

--- a/lib/mix/tasks/dicon.deploy.ex
+++ b/lib/mix/tasks/dicon.deploy.ex
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.Dicon.Deploy do
 
       {:ok, _} = StringIO.close(device)
 
-      config = Mix.Config.merge(sys_config, config)
+      config = Config.Reader.merge(sys_config, config)
       content = :io_lib.format("~p.~n", [config])
       Executor.write_file(conn, sys_config_path, content)
     end

--- a/lib/mix/tasks/dicon.switch.ex
+++ b/lib/mix/tasks/dicon.switch.ex
@@ -40,8 +40,8 @@ defmodule Mix.Tasks.Dicon.Switch do
           end
 
         for host <- config(:hosts, opts) do
-          authority = Keyword.fetch!(host_config(host), :authority)
-          conn = Executor.connect(authority)
+          {authority, host_config} = Keyword.pop!(host_config(host), :authority)
+          conn = Executor.connect(authority, host_config)
           symlink(conn, [target_dir, ?/, version], [target_dir, "/current"])
         end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Dicon.Mixfile do
     [
       app: :dicon,
       version: "0.5.0",
-      elixir: "~> 1.3",
+      elixir: "~> 1.12",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       package: package(),

--- a/test/dicon/executor_test.exs
+++ b/test/dicon/executor_test.exs
@@ -6,15 +6,19 @@ defmodule Dicon.ExecutorTest do
   defmodule FakeExecutor do
     @behaviour Executor
 
-    def connect("fail"), do: {:error, "connect failed"}
-    def connect(term), do: {:ok, term}
+    @impl true
+    def connect("fail", _), do: {:error, "connect failed"}
+    def connect(term, _), do: {:ok, term}
 
+    @impl true
     def exec(_conn, 'fail', _device), do: {:error, "exec failed"}
     def exec(_conn, _command, _device), do: :ok
 
+    @impl true
     def write_file(_conn, 'fail', "fail", _mode), do: {:error, "write failed"}
     def write_file(_conn, _target, _content, _mode), do: :ok
 
+    @impl true
     def copy(_conn, 'fail', 'fail'), do: {:error, "copy failed"}
     def copy(_conn, _source, _target), do: :ok
   end

--- a/test/mix/tasks/dicon.control_test.exs
+++ b/test/mix/tasks/dicon.control_test.exs
@@ -18,10 +18,10 @@ defmodule Mix.Tasks.Dicon.ControlTest do
   test "commands are run and feedback is received" do
     run(["run"])
 
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     assert_receive {:dicon, ^ref, :exec, ["test/current/bin/sample run"]}
 
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     assert_receive {:dicon, ^ref, :exec, ["test/current/bin/sample run"]}
 
     refute_receive {:dicon, _, _, _}
@@ -37,12 +37,12 @@ defmodule Mix.Tasks.Dicon.ControlTest do
     })
 
     run(["run", "--only", "one"])
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 
     run(["run", "--skip", "one"])
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 
@@ -50,9 +50,9 @@ defmodule Mix.Tasks.Dicon.ControlTest do
     refute_receive {:dicon, _, _, _}
 
     run(["run", "--only", "one", "--only", "two"])
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     :ok = flush_reply(ref)
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 
@@ -85,7 +85,9 @@ defmodule Mix.Tasks.Dicon.ControlTest do
     })
 
     run(["run"])
-    assert_receive {:dicon, ref, :connect, ["one"]}
+
+    assert_receive {:dicon, ref, :connect,
+                    ["one", [os_env: %{"IS_FOO" => "yes it is", "BAR" => "baz\"bong"}]]}
 
     assert_receive {:dicon, ^ref, :exec,
                     [~S(BAR="baz\"bong" IS_FOO="yes it is" test/current/bin/sample run)]}

--- a/test/mix/tasks/dicon.deploy_test.exs
+++ b/test/mix/tasks/dicon.deploy_test.exs
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Dicon.DeployTest do
 
     run([source, "0.1.0"])
 
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     assert_receive {:dicon, ^ref, :exec, ["mkdir -p test"]}
     assert_receive {:dicon, ^ref, :copy, [^source, ^release_file]}
     assert_receive {:dicon, ^ref, :exec, ["mkdir -p test/0.1.0"]}
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Dicon.DeployTest do
                       :write
                     ]}
 
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     assert_receive {:dicon, ^ref, :exec, ["mkdir -p test"]}
     assert_receive {:dicon, ^ref, :copy, [^source, ^release_file]}
     assert_receive {:dicon, ^ref, :exec, ["mkdir -p test/0.1.0"]}
@@ -63,12 +63,12 @@ defmodule Mix.Tasks.Dicon.DeployTest do
     end)
 
     run([source, "0.1.0", "--only", "one"])
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 
     run([source, "0.1.0", "--skip", "one"])
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 
@@ -80,9 +80,9 @@ defmodule Mix.Tasks.Dicon.DeployTest do
     end)
 
     run([source, "0.1.0", "--only", "one", "--only", "two"])
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     :ok = flush_reply(ref)
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 

--- a/test/mix/tasks/dicon.switch_test.exs
+++ b/test/mix/tasks/dicon.switch_test.exs
@@ -13,10 +13,10 @@ defmodule Mix.Tasks.Dicon.SwitchTest do
 
     run(["0.1.0"])
 
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     assert_receive {:dicon, ^ref, :exec, ["ln -snf $PWD/test/0.1.0 $PWD/test/current"]}
 
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     assert_receive {:dicon, ^ref, :exec, ["ln -snf $PWD/test/0.1.0 $PWD/test/current"]}
 
     refute_receive {:dicon, _, _, _}
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Dicon.SwitchTest do
 
     run(["0.2.0"])
 
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     assert_receive {:dicon, ^ref, :exec, ["ln -snf /home/test/0.2.0 /home/test/current"]}
 
     refute_receive {:dicon, _, _, _}
@@ -46,12 +46,12 @@ defmodule Mix.Tasks.Dicon.SwitchTest do
     })
 
     run(["0.2.0", "--only", "one"])
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 
     run(["0.2.0", "--skip", "one"])
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 
@@ -59,9 +59,9 @@ defmodule Mix.Tasks.Dicon.SwitchTest do
     refute_receive {:dicon, _, _, _}
 
     run(["0.2.0", "--only", "one", "--only", "two"])
-    assert_receive {:dicon, ref, :connect, ["one"]}
+    assert_receive {:dicon, ref, :connect, ["one", []]}
     :ok = flush_reply(ref)
-    assert_receive {:dicon, ref, :connect, ["two"]}
+    assert_receive {:dicon, ref, :connect, ["two", []]}
     :ok = flush_reply(ref)
     refute_receive {:dicon, _, _, _}
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -39,12 +39,14 @@ defmodule DiconTest.Case do
     end)
   end
 
-  def connect(authority) do
+  @impl true
+  def connect(authority, host_config) do
     conn = make_ref()
-    notify_test({:dicon, conn, :connect, [authority]})
+    notify_test({:dicon, conn, :connect, [authority, host_config]})
     {:ok, conn}
   end
 
+  @impl true
   def exec(conn, command, device) do
     command = List.to_string(command)
     run_callback(command, device)
@@ -52,6 +54,7 @@ defmodule DiconTest.Case do
     :ok
   end
 
+  @impl true
   def write_file(conn, target, content, mode) do
     content = IO.iodata_to_binary(content)
     target = List.to_string(target)
@@ -59,6 +62,7 @@ defmodule DiconTest.Case do
     :ok
   end
 
+  @impl true
   def copy(conn, source, target) do
     source = List.to_string(source)
     target = List.to_string(target)


### PR DESCRIPTION
Allows jump authority option to be set.

Changes to dicon required by https://github.com/forzafootball/ex-deployment-ops/pull/7